### PR TITLE
Update youtube-player.service.ts (HTTP to HTTPS)

### DIFF
--- a/src/youtube-player.service.ts
+++ b/src/youtube-player.service.ts
@@ -37,7 +37,7 @@ export class YoutubePlayerService {
     const doc = window.document;
     let playerApiScript = doc.createElement("script");
     playerApiScript.type = "text/javascript";
-    playerApiScript.src = "http://www.youtube.com/iframe_api";
+    playerApiScript.src = "https://www.youtube.com/iframe_api";
     doc.body.appendChild(playerApiScript);
   }
 


### PR DESCRIPTION
Corrected the following error:
Failed to execute 'postMessage' on 'DOMWindow': The target origin provided
('https://www.youtube.com') does not match the recipient window's origin