### PR TITLE
Fix import  @types/youtube to make it compatible with typescript 4.7 

### DIFF
--- a/projects/ngx-youtube-player/src/lib/models.ts
+++ b/projects/ngx-youtube-player/src/lib/models.ts
@@ -1,4 +1,4 @@
-import '@types/youtube';
+import 'youtube';
 import { EventEmitter } from '@angular/core';
 
 export interface IPlayerOutputs {


### PR DESCRIPTION
This solves the error when running  `npm start`  with  "typescript": "4.7.4". 

```
Error: node_modules/ngx-youtube-player/lib/models.d.ts:1:8 - error TS6137: Cannot import type declaration files. Consider importing 'youtube' instead of '@types/youtube'.

1 import '@types/youtube';
```